### PR TITLE
Check if day of week filter is "All" before unsetting rows

### DIFF
--- a/parish_school_locator.module
+++ b/parish_school_locator.module
@@ -296,11 +296,15 @@ function parish_school_locator_preprocess_views_view_field(&$variables) {
         // Get day of week parameter value
         $day = $query['field_day_of_week_value'];
 
-        // Check if row's day of week value matches URI parameter value
-        if ($variables['row']->mass_times__field_day_of_week_field_day_of_week_value != $day) {
+        // Make sure day of week parameter is not set to 'All'
+        if ($day != 'All') {
 
-          // Hide non-matching rows' output
-          unset($variables['output']);
+          // Check if row's day of week value matches URI parameter value
+          if ($variables['row']->mass_times__field_day_of_week_field_day_of_week_value != $day) {
+
+            // Hide non-matching rows' output
+            unset($variables['output']);
+          }
         }
       }
     }


### PR DESCRIPTION
Mike - looks like the problem was that the code was treating the "All" parameter for the day of the week filter as a day of the week and then unsetting all the service rows because none of them were for a day of the week called "All."

Added a conditional to check whether the parameter is "All" before unsetting any rows.

Let me know if this doesn't fix the problem.